### PR TITLE
Sending and displaying message fix

### DIFF
--- a/server/messenger_backend/views/api/conversations.py
+++ b/server/messenger_backend/views/api/conversations.py
@@ -60,7 +60,7 @@ class Conversations(APIView):
 
                 conversations_response.append(convo_dict)
             conversations_response.sort(
-                key=lambda convo: convo["messages"][0]["createdAt"],
+                key=lambda convo: convo["messages"][-1]["createdAt"],
                 reverse=True,
             )
             return JsonResponse(


### PR DESCRIPTION
## Description

Fixes #1 
Two main fixes. One in sever Conversation api, the other in client components Home.

Conversation API fix (server/.../api/conversations.py):
Problem: Conversation messages were not displaying in the correct order and not showing the correct preview msg.
Solution: 
- Removed "-" part of tag on order_by function (ln 28)
- Changed "latestMessageText" message index to -1 from 0 (get the last message added to messages)

Home Component fix (client/src/components/Home.js):
Problem: Messages would not be shown after sending.
Solution:
- Ensured saveMessage would finish within postMessage by wrapping the rest of the function in a then promise function (ln 67)
- Modified addMessageToConversation and addNewConvo to copy the existing state of conversations, modify, and set the new updated state.

## Notes on your approach and thought process

Please leave some notes explaining your thought process and your approach to solving this issue.
I started by using cypress to see what was breaking, then I traced the client side problem down fast. I had a hunch at the time the message order and latest message preview was a server side issue, of which I traced it to the conversations api.

When working on the client I followed the path of the data and found that the data assignment in postMessage was being skipped. Noticing it was a promise, I decided to wrap it in a then function so it would properly assign the variable after the data was posted.

After that I focused on the hooks allowing the data to be displayed and found that treating the existing state and it's array objects as immutable solved the issue.

## Further comments (optional)