### PR TITLE
DRAFT - Changes for 'multi user chat' support

### DIFF
--- a/server/messenger_backend/models/conversation.py
+++ b/server/messenger_backend/models/conversation.py
@@ -1,5 +1,6 @@
 from django.db import models
 from django.db.models import Q
+from django.contrib.postgres.fields import HStoreField
 
 from . import utils
 from .user import User
@@ -7,14 +8,12 @@ from .user import User
 
 class Conversation(utils.CustomModel):
 
-    user1 = models.ForeignKey(
-        User, on_delete=models.CASCADE, db_column="user1Id", related_name="+"
-    )
-    user2 = models.ForeignKey(
-        User, on_delete=models.CASCADE, db_column="user2Id", related_name="+", 
-    )
+    users = models.ManyToManyField(User, db_column="userIds", related_name="+")
     createdAt = models.DateTimeField(auto_now_add=True, db_index=True)
     updatedAt = models.DateTimeField(auto_now=True)
+    usersLastReadAt = HStoreField()
+    convoPhotoUrl = models.TextField(default=None, blank=True, null=True)
+    convoName = models.TextField(default=None, blank=True, null=True)
 
     # find conversation given two user Ids
     def find_conversation(user1Id, user2Id):


### PR DESCRIPTION
## Description
Closes #5 
Just to preface this PR, there would be a lot of work to do, however to the request of the ticket this is what I think would need to be changed in the db model.

## Database changes

The objective with this issue is to add the ability to have multiple users within one conversation.
We can start to do this by having a many-to-many field instead of a foreign key field (which is one-to-many). This will allow django and postgresql to create an interim table showing relationships between user objects and conversation objects. This causes problems in our existing code which will be brought up later in this draft.

Next we assume we want to retain our existing read status functions. To solve having multiple users, we'll use a HStore field which is a key value field perfect for logging each user's last read timestamp. (to make this clear, we would be taking a user id as a key, and the timestamp as a value).

Lastly for the database related changes, we would need to alter our find_conversation function within models/conversation.py. instead of directly querying for a user id match, we would have to query each conversation, and then their pool of users. This should make the function run faster since the old version was performing four queries for one result.

As for what gets passed when a conversation object is requested, we now would send these new variables as arrays or JSON objects.

## Question 1

Most of the changes would be small, such as user comparison if statements. There would also need to be new features to accommodate the group functionality.

To start, as I outlined, there are a lot of statements that compare current user or other user ids, these would have to be changed in one of the following two ways:
- Check if the user id is in the conversation.users group rather than directly comparing ids (see components/home.js ln 134)
- Check that the desired id is not the user id rather than is (see components/home.js ln 84)
While this is a seemingly simple problem, it appears to be deep rooted as several files (client side) have variables named "otherUser" which can be left as is, however it could cause confusion now since there are more than one other users.

Continuing, chat features would need to be updated to reflect the new capabilities. This would include things like:
- Other user text bubble colors or identifiers
- Other user text bubble name titles
- Group conversation name (can be null, if null then it would be a list of the user's names)
- Group conversation picture (can be null)
- Group administrative tools (add, rename, remove, admin status)
- Removing online status for groups (or any conversation with more than 2 users)

The profile/avatar icon and online status would need to be carefully looked at since the logic in those areas are dependent on one id, they would need to be switched over to a system like mentioned above.

## Question 2

We could start the migration process by running one instance of each database (old and new), then creating a function that would fill in the new variables (ie, user1, user 2 -> users) via ACID transactions to ensure no data loss. Once all entries have been filled we would then replace the old database with the new one during a low traffic time. Unfortunately some users may be disrupted as a result but seeing how the app is in a production environment, it would need to be taken offline for a (scheduled) maintenance period. 

## Alternate Solutions

There were two other way I was thinking about this problem.
- Use the user model as the center of the database instead of the conversations model.
- Create a new table specifically for groups (this is a variation of the many-to-many field)

For the first one, since we would have several users in each I had the idea of using a chat id field that would store the active chats a user is a part of. This after some thought wasn't a good idea since there would be a much larger amount of work done for a more complicated solution.

For the second idea, the thought process was to keep the existing code as intact as possible. This would mean that all the current 2 person conversations would still work as normal and when a user added a new person it would create a new entry in a group-conversation table. While this solution takes up more space and arguably is more complex, it would need less alteration to the code to integrate in some areas. However in most cases it would introduce a lot of repetitive code which would only cause more confusion to future new developers. 